### PR TITLE
Remove `bottle :unneeded`

### DIFF
--- a/lazydocker.rb
+++ b/lazydocker.rb
@@ -6,7 +6,6 @@ class Lazydocker < Formula
   desc "A simple terminal UI for docker, written in Go"
   homepage "https://github.com/jesseduffield/lazydocker/"
   version "0.12"
-  bottle :unneeded
 
   if OS.mac? && Hardware::CPU.intel?
     url "https://github.com/jesseduffield/lazydocker/releases/download/v0.12/lazydocker_0.12_Darwin_x86_64.tar.gz"


### PR DESCRIPTION
This declaration does nothing and was deprecated. Currently, tapping `lazydocker`
results in loud homebrew complaints:

```
Warning: Calling bottle :unneeded is deprecated! There is no replacement.
Please report this issue to the jesseduffield/lazydocker tap (not Homebrew/brew or Homebrew/core):
  /usr/local/Homebrew/Library/Taps/jesseduffield/homebrew-lazydocker/lazydocker.rb:9
```

This is the same as https://github.com/jesseduffield/homebrew-lazydocker/pull/2 but without the extra merge commit.

See also: https://github.com/jesseduffield/lazydocker/issues/273, https://github.com/jesseduffield/homebrew-lazydocker/issues/1